### PR TITLE
gh-1: Remove detailed build report from GitHub CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,4 +52,4 @@ jobs:
       with:
         submodules: true
     - name: Build and run tests
-      run: cargo test --verbose
+      run: cargo test


### PR DESCRIPTION
Removal of build log verbosity reduces log size from 3519 lines to 102 (no need to doomscroll in case of error analysis).

- Issue: gh-1