### PR TITLE
gh-1: Delete hello function

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,11 +5,6 @@ use std::error::Error;
 use std::fmt::{Debug, Display, Formatter, Result};
 use std::ops::Range;
 
-#[must_use]
-pub const fn hello() -> bool {
-    true
-}
-
 /// An error message that can be attributed to a certain piece of source code.
 #[derive(Debug, Eq, PartialEq)]
 pub struct SourceCodeError {

--- a/tests/smoke.rs
+++ b/tests/smoke.rs
@@ -1,7 +1,0 @@
-use embedded_ecmascript::hello;
-
-#[test]
-fn test_import() -> Result<(), Box<dyn std::error::Error>> {
-    assert!(hello());
-    Ok(())
-}


### PR DESCRIPTION
After we added a proper crate member with an associated proper test, the hello function for a smoke test is no longer relevant.

Also it fixes irrelevant linter errors:

```plain
error: this function's return value is unnecessary
 --> tests/smoke.rs:4:1
  |
4 | / fn test_import() -> Result<(), Box<dyn std::error::Error>> {
5 | |     assert!(hello());
6 | |     Ok(())
7 | | }
  | |_^
  |
  = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_wraps
  = note: `-D clippy::unnecessary-wraps` implied by `-D warnings`
  = help: to override `-D warnings` add `#[allow(clippy::unnecessary_wraps)]`
help: remove the return type...
  |
4 | fn test_import() -> Result<(), Box<dyn std::error::Error>> {
  |                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
help: ...and then remove returned values
  |
6 -     Ok(())
6 +     
  |
```

- Issue: gh-1