### PR TITLE
gh-22: Disable `clippy::large_stack_frames` check

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,6 +44,7 @@ jobs:
         -W clippy::pedantic
         -W clippy::nursery
         -W clippy::cargo
+        -A clippy::large_stack_frames
   unit:
     name: Library
     runs-on: ubuntu-latest


### PR DESCRIPTION
None of the existing function or test allocates arrays or a dosen of variables on stack. Thus, we conclude that these big on-stack arrays should come from expansion of `#[values(...)]` in tests.

- Issue: gh-22