### PR TITLE
gh-12: Prettify `_tokenizer.space` module

### DIFF
--- a/src/_tokenizer/space.rs
+++ b/src/_tokenizer/space.rs
@@ -51,7 +51,7 @@
 //! > prior permission. Title to copyright in this work will at all times remain
 //! > with copyright holders.
 
-/// Tries to match start of a string against `<ZWNJ>` entry of Table 34:
+/// Try to match start of a string against `<ZWNJ>` entry of Table 34:
 /// Format-Control Code Point Usage:
 ///
 /// > | Code Point | Name                  | Abbreviation |

--- a/src/_tokenizer/space.rs
+++ b/src/_tokenizer/space.rs
@@ -99,17 +99,15 @@ mod tests {
         type Err = CaseParameterError;
 
         fn from_str(text: &str) -> Result<Self, Self::Err> {
-            match text {
-                "\u{200C}" => Ok(Self {
-                    token: text.to_string(),
-                    parser: Box::new(crate::_tokenizer::space::match_zwnj)}
-                ),
-                "\u{200D}" => Ok(Self {
-                    token: text.to_string(),
-                    parser: Box::new(crate::_tokenizer::space::match_zwj)}
-                ),
-                _ => Err(Self::Err{})
-            }
+            let associated_parser: ParserCallable = match text {
+                "\u{200C}" => Box::new(crate::_tokenizer::space::match_zwnj),
+                "\u{200D}" => Box::new(crate::_tokenizer::space::match_zwj),
+                _ => Box::new(|_| Option::None)
+            };
+            Ok(Self {
+                token: text.to_string(),
+                parser: associated_parser
+            })
         }
     }
 

--- a/src/_tokenizer/space.rs
+++ b/src/_tokenizer/space.rs
@@ -88,6 +88,11 @@ mod tests {
 
     type ParserCallable = Box<dyn Fn(&str) -> Option<((), &str)>>;
 
+    /// A test case for a parser, creatable from a literal the parser
+    /// is documented to process.
+    ///
+    /// The creation is performed in [`TerminalCase.from_str`] and invoked
+    /// by the `#[values("\u{...}, ...)]` macro provided by rstest.
     struct TerminalCase {
         token: String,
         parser: ParserCallable
@@ -99,14 +104,14 @@ mod tests {
         type Err = CaseParameterError;
 
         fn from_str(text: &str) -> Result<Self, Self::Err> {
-            let associated_parser: ParserCallable = match text {
+            let tested_parser: ParserCallable = match text {
                 "\u{200C}" => Box::new(crate::_tokenizer::space::match_zwnj),
                 "\u{200D}" => Box::new(crate::_tokenizer::space::match_zwj),
                 _ => Box::new(|_| Option::None)
             };
             Ok(Self {
                 token: text.to_string(),
-                parser: associated_parser
+                parser: tested_parser
             })
         }
     }


### PR DESCRIPTION
After adding `match_zwj` function almost identical to `match_zwnj`, I found repetitions that can be moved out:

- `Try to match` vs `Tries to match` in function documentation
- repetitive `match` branches in `TerminalCase::from_str`

Issue: gh-12