### PR TITLE
gh-12: Replace `Box<dyn Fn(...)>` with `fn(...)`

### DIFF
--- a/src/_tokenizer/space.rs
+++ b/src/_tokenizer/space.rs
@@ -145,8 +145,6 @@ mod tests {
     use rstest::rstest;
     use std::str::FromStr;
 
-    type ParserCallable = Box<dyn Fn(&str) -> Option<((), &str)>>;
-
     /// A test case for a parser, creatable from a literal the parser
     /// is documented to process.
     ///
@@ -154,7 +152,7 @@ mod tests {
     /// by the `#[values("\u{...}, ...)]` macro provided by rstest.
     struct TerminalCase {
         token: String,
-        parser: ParserCallable
+        parser: fn(&str) -> Option<((), &str)>
     }
 
     struct CaseParameterError;

--- a/src/_tokenizer/space.rs
+++ b/src/_tokenizer/space.rs
@@ -157,7 +157,7 @@ mod tests {
 
     struct CaseParameterError;
 
-    fn return_none(_: &str) {
+    fn return_none(_: &str) -> Option<((), &str)> {
         Option::None
     }
 

--- a/src/_tokenizer/space.rs
+++ b/src/_tokenizer/space.rs
@@ -157,18 +157,22 @@ mod tests {
 
     struct CaseParameterError;
 
+    fn return_none(_: &str) {
+        Option::None
+    }
+
     impl FromStr for TerminalCase {
         type Err = CaseParameterError;
 
         fn from_str(text: &str) -> Result<Self, Self::Err> {
-            let tested_parser: ParserCallable = match text {
-                "\u{200C}" => Box::new(crate::_tokenizer::space::match_zwnj),
-                "\u{200D}" => Box::new(crate::_tokenizer::space::match_zwj),
-                "\u{FEFF}" => Box::new(crate::_tokenizer::space::match_zwnbsp),
-                "\u{0009}" => Box::new(crate::_tokenizer::space::match_tab),
-                "\u{000B}" => Box::new(crate::_tokenizer::space::match_vt),
-                "\u{000C}" => Box::new(crate::_tokenizer::space::match_ff),
-                _ => Box::new(|_| Option::None)
+            let tested_parser = match text {
+                "\u{200C}" => crate::_tokenizer::space::match_zwnj,
+                "\u{200D}" => crate::_tokenizer::space::match_zwj,
+                "\u{FEFF}" => crate::_tokenizer::space::match_zwnbsp,
+                "\u{0009}" => crate::_tokenizer::space::match_tab,
+                "\u{000B}" => crate::_tokenizer::space::match_vt,
+                "\u{000C}" => crate::_tokenizer::space::match_ff,
+                _ => return_none
             };
             Ok(Self {
                 token: text.to_string(),

--- a/src/_tokenizer/space.rs
+++ b/src/_tokenizer/space.rs
@@ -157,7 +157,7 @@ mod tests {
 
     struct CaseParameterError;
 
-    fn return_none(_: &str) -> Option<((), &str)> {
+    const fn return_none(_: &str) -> Option<((), &str)> {
         Option::None
     }
 


### PR DESCRIPTION
If we call plain functions only, a boxed reference to any callable is the redundant abstraction.

- Issue: gh-12