### PR TITLE
gh-12: Prepare actual tests for double invocation

### DIFF
--- a/src/_tokenizer/space.rs
+++ b/src/_tokenizer/space.rs
@@ -238,6 +238,41 @@ mod tests {
         }
     }
 
+    fn test_token(tok: &str, sep: &str, parser: fn(&str) -> Option<((), &str)>) {
+        // Empty strings do not match
+        assert_eq!(parser(""), None);
+
+        // Skip false match when the function recognizes a separator.
+        if parser(sep) != Some(((), "")) {
+            // Non-matching strings do not match
+            assert_eq!(parser(sep), None);
+
+            // Catch arbitrary (regex-like) match of a necessary symbol
+            assert_eq!(parser(format!("{sep}{tok}").as_ref()), None);
+        }
+
+        // Test EOF match
+        assert_eq!(parser(tok), Some(((), "")));
+
+        // Test non-EOF match
+        assert_eq!(
+            parser(format!("{tok}{sep}").as_ref()),
+            Some(((), sep))
+        );
+
+        // Test repetitions
+        assert_eq!(
+            parser(format!("{tok}{tok}").as_ref()),
+            Some(((), tok))
+        );
+
+        // Test separated repetitions
+        assert_eq!(
+            parser(format!("{tok}{sep}{tok}").as_ref()),
+            Some(((), format!("{sep}{tok}").as_ref()))
+        );
+    }
+
     #[rstest]
     fn match_space(
         #[values(
@@ -251,40 +286,6 @@ mod tests {
         #[values("foo", " ")]
         separator: &str
     ) {
-        let tok = case.token.as_ref();
-        let sep = separator;
-
-        // Empty strings do not match
-        assert_eq!((case.parser)(""), None);
-
-        // Skip false match when the function recognizes a separator.
-        if (case.parser)(sep) != Some(((), "")) {
-            // Non-matching strings do not match
-            assert_eq!((case.parser)(sep), None);
-
-            // Catch arbitrary (regex-like) match of a necessary symbol
-            assert_eq!((case.parser)(format!("{sep}{tok}").as_ref()), None);
-        }
-
-        // Test EOF match
-        assert_eq!((case.parser)(tok), Some(((), "")));
-
-        // Test non-EOF match
-        assert_eq!(
-            (case.parser)(format!("{tok}{sep}").as_ref()),
-            Some(((), sep))
-        );
-
-        // Test repetitions
-        assert_eq!(
-            (case.parser)(format!("{tok}{tok}").as_ref()),
-            Some(((), tok))
-        );
-
-        // Test separated repetitions
-        assert_eq!(
-            (case.parser)(format!("{tok}{sep}{tok}").as_ref()),
-            Some(((), format!("{sep}{tok}").as_ref()))
-        );
+        test_token(case.token.as_ref(), separator, case.parser);
     }
 }


### PR DESCRIPTION
Soon we will call whitespace parser tests once for `case.parser` (as before) and once for a newly added `match_whitespace`. So we move out the tests into a separate function.

- Issue: gh-12