### PR TITLE
gh-9: Merge all TerminalCase into a single, global one

### DIFF
--- a/src/_tokenizer/mod.rs
+++ b/src/_tokenizer/mod.rs
@@ -12,6 +12,8 @@ pub mod space;
 
 #[cfg(test)]
 mod tests {
+    use std::str::FromStr;
+
     pub fn with_term(
         tested: fn(&str) -> Option<((), &str)>,
         input: &str,
@@ -51,7 +53,54 @@ mod tests {
         );
     }
 
-    pub const fn return_none(_: &str) -> Option<((), &str)> {
-        Option::None
+    /// A test case for a parser, creatable from a literal the parser
+    /// is documented to process.
+    ///
+    /// The creation is performed in [`TerminalCase.from_str`] and invoked
+    /// by the `#[values("\u{...}, ...)]` macro provided by rstest.
+    pub struct TerminalCase {
+        pub terminal: String,
+        pub parser: fn(&str) -> Option<((), &str)>
+    }
+
+    pub struct CaseParameterError;
+
+    const fn return_none(_: &str) -> Option<((), &str)> {
+        None
+    }
+
+    impl FromStr for TerminalCase {
+        type Err = CaseParameterError;
+
+        fn from_str(text: &str) -> Result<Self, Self::Err> {
+            let tested_parser = match text {
+                "\u{0009}" => super::space::match_tab,
+                "\u{000A}" => super::space::match_lf,
+                "\u{000B}" => super::space::match_vt,
+                "\u{000C}" => super::space::match_ff,
+                "\u{000D}" => super::space::match_cr,
+                "\u{0020}" => super::space::match_usp,
+                "/" | "/=" => super::punctuators::match_div_punctuator,
+                "}" => super::punctuators::match_right_brace_punctuator,
+                "\u{00A0}" => super::space::match_usp,
+                "\u{1680}" => super::space::match_usp,
+                "\u{2000}" | "\u{2001}" | "\u{2002}" | "\u{2003}" |
+                "\u{2004}" | "\u{2005}" | "\u{2006}" | "\u{2007}" |
+                "\u{2008}" | "\u{2009}" | "\u{200A}" => super::space::match_usp,
+                "\u{200C}" => super::names::match_zwnj,
+                "\u{200D}" => super::names::match_zwj,
+                "\u{2028}" => super::space::match_ls,
+                "\u{2029}" => super::space::match_ps,
+                "\u{202F}" => super::space::match_usp,
+                "\u{205F}" => super::space::match_usp,
+                "\u{3000}" => super::space::match_usp,
+                "\u{FEFF}" => super::space::match_zwnbsp,
+                _ => return_none
+            };
+            Ok(Self {
+                terminal: text.to_string(),
+                parser: tested_parser
+            })
+        }
     }
 }

--- a/src/_tokenizer/mod.rs
+++ b/src/_tokenizer/mod.rs
@@ -73,6 +73,8 @@ mod tests {
         type Err = CaseParameterError;
 
         fn from_str(text: &str) -> Result<Self, Self::Err> {
+            // Keep the arms unmerged for proper sorting of disjoined patterns.
+            #[allow(clippy::match_same_arms)]
             let tested_parser = match text {
                 "\u{0009}" => super::space::match_tab,
                 "\u{000A}" => super::space::match_lf,

--- a/src/_tokenizer/names.rs
+++ b/src/_tokenizer/names.rs
@@ -93,7 +93,7 @@ mod tests {
     /// The creation is performed in [`TerminalCase.from_str`] and invoked
     /// by the `#[values("\u{...}, ...)]` macro provided by rstest.
     struct TerminalCase {
-        token: String,
+        terminal: String,
         parser: fn(&str) -> Option<((), &str)>
     }
 
@@ -109,7 +109,7 @@ mod tests {
                 _ => return_none
             };
             Ok(Self {
-                token: text.to_string(),
+                terminal: text.to_string(),
                 parser: tested_parser
             })
         }
@@ -124,6 +124,6 @@ mod tests {
         #[values("foo", " ")]
         separator: &str
     ) {
-        with_term(tested.parser, tested.token.as_ref(), separator);
+        with_term(tested.parser, tested.terminal.as_ref(), separator);
     }
 }

--- a/src/_tokenizer/names.rs
+++ b/src/_tokenizer/names.rs
@@ -120,10 +120,10 @@ mod tests {
         #[values(
             "\u{200C}", "\u{200D}"
         )]
-        case: TerminalCase,
+        tested: TerminalCase,
         #[values("foo", " ")]
         separator: &str
     ) {
-        with_term(case.parser, case.token.as_ref(), separator);
+        with_term(tested.parser, tested.token.as_ref(), separator);
     }
 }

--- a/src/_tokenizer/names.rs
+++ b/src/_tokenizer/names.rs
@@ -83,37 +83,8 @@ pub fn match_zwj(text: &str) -> Option<((), &str)> {
 
 #[cfg(test)]
 mod tests {
-    use crate::_tokenizer::tests::{return_none, with_term};
+    use crate::_tokenizer::tests::{TerminalCase, with_term};
     use rstest::rstest;
-    use std::str::FromStr;
-
-    /// A test case for a parser, creatable from a literal the parser
-    /// is documented to process.
-    ///
-    /// The creation is performed in [`TerminalCase.from_str`] and invoked
-    /// by the `#[values("\u{...}, ...)]` macro provided by rstest.
-    struct TerminalCase {
-        terminal: String,
-        parser: fn(&str) -> Option<((), &str)>
-    }
-
-    struct CaseParameterError;
-
-    impl FromStr for TerminalCase {
-        type Err = CaseParameterError;
-
-        fn from_str(text: &str) -> Result<Self, Self::Err> {
-            let tested_parser = match text {
-                "\u{200C}" => super::match_zwnj,
-                "\u{200D}" => super::match_zwj,
-                _ => return_none
-            };
-            Ok(Self {
-                terminal: text.to_string(),
-                parser: tested_parser
-            })
-        }
-    }
 
     #[rstest]
     fn match_space(

--- a/src/_tokenizer/punctuators.rs
+++ b/src/_tokenizer/punctuators.rs
@@ -117,10 +117,10 @@ mod tests {
         #[values(
             "}", "/", "/="
         )]
-        case: TerminalCase,
+        tested: TerminalCase,
         #[values("foo", " ")]
         separator: &str
     ) {
-        with_term(case.parser, case.terminal.as_ref(), separator);
+        with_term(tested.parser, tested.terminal.as_ref(), separator);
     }
 }

--- a/src/_tokenizer/punctuators.rs
+++ b/src/_tokenizer/punctuators.rs
@@ -80,37 +80,8 @@ pub fn match_right_brace_punctuator(text: &str) -> Option<((), &str)> {
 
 #[cfg(test)]
 mod tests {
-    use crate::_tokenizer::tests::{return_none, with_term};
+    use crate::_tokenizer::tests::{TerminalCase, with_term};
     use rstest::rstest;
-    use std::str::FromStr;
-
-    /// A test case for a parser, creatable from a literal the parser
-    /// is documented to process.
-    ///
-    /// The creation is performed in [`TerminalCase.from_str`] and invoked
-    /// by the `#[values("\u{...}, ...)]` macro provided by rstest.
-    struct TerminalCase {
-        terminal: String,
-        parser: fn(&str) -> Option<((), &str)>
-    }
-
-    struct CaseParameterError;
-
-    impl FromStr for TerminalCase {
-        type Err = CaseParameterError;
-
-        fn from_str(text: &str) -> Result<Self, Self::Err> {
-            let tested_parser = match text {
-                "}" => super::match_right_brace_punctuator,
-                "/" | "/=" => super::match_div_punctuator,
-                _ => return_none
-            };
-            Ok(Self {
-                terminal: text.to_string(),
-                parser: tested_parser
-            })
-        }
-    }
 
     #[rstest]
     fn match_punctuator(

--- a/src/_tokenizer/space.rs
+++ b/src/_tokenizer/space.rs
@@ -287,47 +287,8 @@ pub fn match_line_terminator_sequence(text: &str) -> Option<((), &str)> {
 
 #[cfg(test)]
 mod tests {
-    use crate::_tokenizer::tests::{return_none, with_term};
+    use crate::_tokenizer::tests::{TerminalCase, with_term};
     use rstest::rstest;
-    use std::str::FromStr;
-
-    /// A test case for a parser, creatable from a literal the parser
-    /// is documented to process.
-    ///
-    /// The creation is performed in [`TerminalCase.from_str`] and invoked
-    /// by the `#[values("\u{...}, ...)]` macro provided by rstest.
-    struct TerminalCase {
-        terminal: String,
-        parser: fn(&str) -> Option<((), &str)>
-    }
-
-    struct CaseParameterError;
-
-    impl FromStr for TerminalCase {
-        type Err = CaseParameterError;
-
-        fn from_str(text: &str) -> Result<Self, Self::Err> {
-            let tested_parser = match text {
-                "\u{FEFF}" => super::match_zwnbsp,
-                "\u{0009}" => super::match_tab,
-                "\u{000B}" => super::match_vt,
-                "\u{000C}" => super::match_ff,
-                "\u{0020}" | "\u{00A0}" | "\u{1680}" | "\u{2000}" | "\u{2001}" |
-                "\u{2002}" | "\u{2003}" | "\u{2004}" | "\u{2005}" | "\u{2006}" |
-                "\u{2007}" | "\u{2008}" | "\u{2009}" | "\u{200A}" | "\u{202F}" |
-                "\u{205F}" | "\u{3000}" => super::match_usp,
-                "\u{000A}" => super::match_lf,
-                "\u{000D}" => super::match_cr,
-                "\u{2028}" => super::match_ls,
-                "\u{2029}" => super::match_ps,
-                _ => return_none
-            };
-            Ok(Self {
-                terminal: text.to_string(),
-                parser: tested_parser
-            })
-        }
-    }
 
     #[rstest]
     fn match_space(

--- a/src/_tokenizer/space.rs
+++ b/src/_tokenizer/space.rs
@@ -339,11 +339,11 @@ mod tests {
             "\u{205F}", "\u{3000}", "\u{000A}", "\u{000D}", "\u{2028}",
             "\u{2029}"
         )]
-        case: TerminalCase,
+        tested: TerminalCase,
         #[values("foo", " ")]
         separator: &str
     ) {
-        with_term(case.parser, case.terminal.as_ref(), separator);
+        with_term(tested.parser, tested.terminal.as_ref(), separator);
     }
 
     #[rstest]
@@ -354,11 +354,11 @@ mod tests {
             "\u{2007}", "\u{2008}", "\u{2009}", "\u{200A}", "\u{202F}",
             "\u{205F}", "\u{3000}"
         )]
-        case: TerminalCase,
+        tested: TerminalCase,
         #[values("foo", " ")]
         separator: &str
     ) {
-        let tok = case.terminal.as_ref();
+        let tok = tested.terminal.as_ref();
         with_term(super::match_whitespace, tok, separator);
     }
 
@@ -367,11 +367,11 @@ mod tests {
         #[values(
             "\u{000A}", "\u{000D}", "\u{2028}", "\u{2029}"
         )]
-        case: TerminalCase,
+        tested: TerminalCase,
         #[values("foo", " ")]
         separator: &str
     ) {
-        let tok = case.terminal.as_ref();
+        let tok = tested.terminal.as_ref();
         with_term(super::match_line_terminator, tok, separator);
         with_term(super::match_line_terminator_sequence, tok, separator);
     }


### PR DESCRIPTION
Now we have a global sample table of what tokens the whole lexer (tokenizer) can process, and all tests refer it as their parameter type for substitution.

- Issue: gh-9