### PR TITLE
gh-16: Make TerminalCase::parser skipping returned object

### DIFF
--- a/src/_tokenizer/mod.rs
+++ b/src/_tokenizer/mod.rs
@@ -68,7 +68,7 @@ mod tests {
     pub struct CaseParameterError;
 
     fn wrap<O, F: Fn(&str) -> Option<(O, &str)> + 'static>(callable: F)
-        -> Box<dyn WrappedParser>
+        -> WrappedParser
     {
         Box::new(move |text| callable(text).map(|result| result.1.to_string()))
     }

--- a/src/_tokenizer/mod.rs
+++ b/src/_tokenizer/mod.rs
@@ -51,6 +51,8 @@ mod tests {
         ]
     }
 
+    pub type WrappedParser = Box<dyn Fn(&str) -> Option<String>>;
+
     /// A test case for a parser to check how it splits the input string into
     /// a literal (ignored) and a tail (checked).
     ///
@@ -60,13 +62,13 @@ mod tests {
         pub terminal: String,
 
         /// A wrapper that discards returned object leaving only a tail
-        pub parser: Box<dyn Fn(&str) -> Option<String>>
+        pub parser: WrappedParser
     }
 
     pub struct CaseParameterError;
 
     fn wrap<O, F: Fn(&str) -> Option<(O, &str)> + 'static>(callable: F)
-        -> Box<dyn Fn(&str) -> Option<String>>
+        -> Box<dyn WrappedParser>
     {
         Box::new(move |text| callable(text).map(|result| result.1.to_string()))
     }

--- a/src/_tokenizer/names.rs
+++ b/src/_tokenizer/names.rs
@@ -83,7 +83,7 @@ pub fn match_zwj(text: &str) -> Option<((), &str)> {
 
 #[cfg(test)]
 mod tests {
-    use crate::_tokenizer::tests::{assert_match_tail, generate_cases, TerminalCase};
+    use crate::_tokenizer::tests::{generate_cases, TerminalCase};
     use rstest::rstest;
 
     #[rstest]
@@ -96,7 +96,7 @@ mod tests {
         separator: &str
     ) {
         for case in generate_cases(&tested.terminal, separator) {
-            assert_match_tail((tested.parser)(&case.input), &case.expected_tail);
+            assert!((tested.parser)(&case.input) == case.expected_tail);
         }
     }
 }

--- a/src/_tokenizer/punctuators.rs
+++ b/src/_tokenizer/punctuators.rs
@@ -80,7 +80,7 @@ pub fn match_right_brace_punctuator(text: &str) -> Option<((), &str)> {
 
 #[cfg(test)]
 mod tests {
-    use crate::_tokenizer::tests::{assert_match_tail, generate_cases, TerminalCase};
+    use crate::_tokenizer::tests::{generate_cases, TerminalCase};
     use rstest::rstest;
 
     #[rstest]
@@ -93,7 +93,7 @@ mod tests {
         separator: &str
     ) {
         for case in generate_cases(&tested.terminal, separator) {
-            assert_match_tail((tested.parser)(&case.input), &case.expected_tail);
+            assert!((tested.parser)(&case.input) == case.expected_tail);
         }
     }
 }

--- a/src/_tokenizer/space.rs
+++ b/src/_tokenizer/space.rs
@@ -287,7 +287,7 @@ pub fn match_line_terminator_sequence(text: &str) -> Option<((), &str)> {
 
 #[cfg(test)]
 mod tests {
-    use crate::_tokenizer::tests::{assert_match_tail, generate_cases, TerminalCase};
+    use crate::_tokenizer::tests::{generate_cases, TerminalCase};
     use rstest::rstest;
 
     #[rstest]
@@ -308,7 +308,7 @@ mod tests {
             return;
         }
         for case in generate_cases(&tested.terminal, separator) {
-            assert_match_tail((tested.parser)(&case.input), &case.expected_tail);
+            assert!((tested.parser)(&case.input) == case.expected_tail);
         }
     }
 
@@ -328,10 +328,10 @@ mod tests {
             return;
         }
         for case in generate_cases(&tested.terminal, separator) {
-            assert_match_tail((tested.parser)(&case.input), &case.expected_tail);
-            assert_match_tail(
-                super::match_whitespace(&case.input),
-                &case.expected_tail
+            assert!((tested.parser)(&case.input) == case.expected_tail);
+            assert!(
+                super::match_whitespace(&case.input).map(|result| result.1) ==
+                case.expected_tail.as_deref()
             );
         };
     }
@@ -349,13 +349,13 @@ mod tests {
         // match_line_terminator and match_line_terminator_sequence. Thus,
         // tested.parser is touched in match_space but deliberately unused here.
         for case in generate_cases(&tested.terminal, separator) {
-            assert_match_tail(
-                super::match_line_terminator(&case.input),
-                &case.expected_tail
+            assert!(
+                super::match_line_terminator(&case.input).map(|result| result.1) ==
+                case.expected_tail.as_deref()
             );
-            assert_match_tail(
-                super::match_line_terminator_sequence(&case.input),
-                &case.expected_tail
+            assert!(
+                super::match_line_terminator_sequence(&case.input).map(|result| result.1) ==
+                case.expected_tail.as_deref()
             );
         }
     }
@@ -366,9 +366,9 @@ mod tests {
         separator: &str
     ) {
         for case in generate_cases("\r\n", separator) {
-            assert_match_tail(
-                super::match_line_terminator_sequence(&case.input),
-                &case.expected_tail
+            assert!(
+                super::match_line_terminator_sequence(&case.input).map(|result| result.1) ==
+                case.expected_tail.as_deref()
             );
         }
     }


### PR DESCRIPTION
It allows to mix functions returning `Option<O, &str>` in the same match even for different recognized terminals `O`.

As a disadvantage, we cannot check the terminals in `#[rstest]` tests with `TerminalCase` table parameters; we need separate test functions for this.

- Issue: gh-16