### PR TITLE
gh-9: Simplify tuple parameter usage

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,6 +36,21 @@ jobs:
       #
       # We use `-W` because `RUSTFLAGS=-Dwarnings` turns warnings into errors
       # anyway.
+      #
+      # Also, we explicitly allow some diagnostics:
+      #
+      # - clippy::ignored_unit_patterns: we replace a numeric name of a single
+      #   enum field (like `|foo| foo.1`) with partial tuple unpacking (like
+      #   `|(_, bar) bar|`) so the purpose of the field is instantly
+      #   understood by a first-time reader. So replacing `_` with `()` cannot
+      #   be done here
+      #
+      # - clippy::large_stack_frames: rctest triggers this diagnostics so
+      #   disable it until we sort out what causes it
+      #
+      # - clippy::too_many_lines: allow large lexer matchers as
+      #   the ECMAScript specification prescribes
+      #  
       run: >
         cargo clippy
         --all-targets
@@ -44,6 +59,7 @@ jobs:
         -W clippy::pedantic
         -W clippy::nursery
         -W clippy::cargo
+        -A clippy::ignored_unit_patterns
         -A clippy::large_stack_frames
         -A clippy::too_many_lines
   unit:

--- a/src/_tokenizer/mod.rs
+++ b/src/_tokenizer/mod.rs
@@ -71,7 +71,7 @@ mod tests {
     fn wrap<O, F: Fn(&str) -> Option<(O, &str)> + 'static>(callable: F)
         -> WrappedParser
     {
-        Box::new(move |text| callable(text).map(|result| result.1.to_string()))
+        Box::new(move |text| callable(text).map(|(_, tail)| tail.to_string()))
     }
 
     impl FromStr for TerminalCase {

--- a/src/_tokenizer/punctuators.rs
+++ b/src/_tokenizer/punctuators.rs
@@ -324,7 +324,6 @@ pub fn match_div_punctuator(text: &str) -> Option<(DivPunctuator, &str)> {
         .or_else(|| text.strip_prefix('/').map(
             |tail| (DivPunctuator::Division, tail)
         ))
-            
 }
 
 /// Try to match start of a string against `RightBracePunctuator` production:

--- a/src/_tokenizer/space.rs
+++ b/src/_tokenizer/space.rs
@@ -330,7 +330,7 @@ mod tests {
         for case in generate_cases(&tested.terminal, separator) {
             assert!((tested.parser)(&case.input) == case.expected_tail);
             assert!(
-                super::match_whitespace(&case.input).map(|result| result.1) ==
+                super::match_whitespace(&case.input).map(|(_, tail)| tail) ==
                 case.expected_tail.as_deref()
             );
         };
@@ -350,11 +350,11 @@ mod tests {
         // tested.parser is touched in match_space but deliberately unused here.
         for case in generate_cases(&tested.terminal, separator) {
             assert!(
-                super::match_line_terminator(&case.input).map(|result| result.1) ==
+                super::match_line_terminator(&case.input).map(|(_, tail)| tail) ==
                 case.expected_tail.as_deref()
             );
             assert!(
-                super::match_line_terminator_sequence(&case.input).map(|result| result.1) ==
+                super::match_line_terminator_sequence(&case.input).map(|(_, tail)| tail) ==
                 case.expected_tail.as_deref()
             );
         }
@@ -367,7 +367,7 @@ mod tests {
     ) {
         for case in generate_cases("\r\n", separator) {
             assert!(
-                super::match_line_terminator_sequence(&case.input).map(|result| result.1) ==
+                super::match_line_terminator_sequence(&case.input).map(|(_, tail)| tail) ==
                 case.expected_tail.as_deref()
             );
         }


### PR DESCRIPTION
Replace `|foo| foo.1` with `|(_, bar) bar|`. No longer opaque meaning behind numeric fields; we name these fields in place of usage.

- Issue: gh-9