### PR TITLE
gh-45: Deduplicate in-test parse tail extraction

### DIFF
--- a/src/_tokenizer/mod.rs
+++ b/src/_tokenizer/mod.rs
@@ -52,6 +52,10 @@ mod tests {
         ]
     }
 
+    pub fn unwrap_tail<X>(parsed: Option<(X, &str)>) -> Option<String> {
+        parsed.map(|(_, tail)| tail.to_string())
+    }
+
     pub type WrappedParser = Box<dyn Fn(&str) -> Option<String>>;
 
     /// A test case for a parser to check how it splits the input string into

--- a/src/_tokenizer/names.rs
+++ b/src/_tokenizer/names.rs
@@ -369,7 +369,7 @@ pub fn match_unicode_id_continue(text: &str) -> Option<(char, &str)> {
 
 #[cfg(test)]
 mod tests {
-    use crate::_tokenizer::tests::{generate_cases, TerminalCase};
+    use crate::_tokenizer::tests::{generate_cases, TerminalCase, unwrap_tail};
     use rstest::rstest;
 
      #[rstest]
@@ -385,8 +385,8 @@ mod tests {
         let safe_cases = all.iter().filter(|case| !case.input.starts_with("foo"));
         for case in safe_cases {
             assert_eq!(
-                super::match_identifier_start_char(&case.input).map(|(_, tail)| tail),
-                case.expected_tail.as_deref()
+                unwrap_tail(super::match_identifier_start_char(&case.input)),
+                case.expected_tail
             );
         }
     }
@@ -404,8 +404,8 @@ mod tests {
         let safe_cases = all.iter().filter(|case| !case.input.starts_with("foo"));
         for case in safe_cases {
             assert_eq!(
-                super::match_identifier_part_char(&case.input).map(|(_, tail)| tail),
-                case.expected_tail.as_deref()
+                unwrap_tail(super::match_identifier_part_char(&case.input)),
+                case.expected_tail
             );
         }
     }

--- a/src/_tokenizer/punctuators.rs
+++ b/src/_tokenizer/punctuators.rs
@@ -363,7 +363,7 @@ pub fn match_right_brace_punctuator(text: &str) -> Option<((), &str)> {
 
 #[cfg(test)]
 mod tests {
-    use crate::_tokenizer::tests::{generate_cases, TerminalCase};
+    use crate::_tokenizer::tests::{generate_cases, TerminalCase, unwrap_tail};
     use rstest::rstest;
 
     /// Remove cases with token repetitions ("{token}{token}") that give
@@ -425,8 +425,8 @@ mod tests {
         let safe_cases = all.iter().filter(|case| !is_double(&case.input));
         for case in safe_cases {
             assert_eq!(
-                super::match_punctuator(&case.input).map(|(_, tail)| tail),
-                case.expected_tail.as_deref()
+                unwrap_tail(super::match_punctuator(&case.input)),
+                case.expected_tail
             );
         }
     }

--- a/src/_tokenizer/space.rs
+++ b/src/_tokenizer/space.rs
@@ -287,7 +287,7 @@ pub fn match_line_terminator_sequence(text: &str) -> Option<((), &str)> {
 
 #[cfg(test)]
 mod tests {
-    use crate::_tokenizer::tests::{generate_cases, TerminalCase};
+    use crate::_tokenizer::tests::{generate_cases, TerminalCase, unwrap_tail};
     use rstest::rstest;
 
     #[rstest]
@@ -330,8 +330,8 @@ mod tests {
         for case in generate_cases(&tested.terminal, separator) {
             assert!((tested.parser)(&case.input) == case.expected_tail);
             assert!(
-                super::match_whitespace(&case.input).map(|(_, tail)| tail) ==
-                case.expected_tail.as_deref()
+                unwrap_tail(super::match_whitespace(&case.input)) ==
+                case.expected_tail
             );
         };
     }
@@ -350,12 +350,12 @@ mod tests {
         // tested.parser is touched in match_space but deliberately unused here.
         for case in generate_cases(&tested.terminal, separator) {
             assert!(
-                super::match_line_terminator(&case.input).map(|(_, tail)| tail) ==
-                case.expected_tail.as_deref()
+                unwrap_tail(super::match_line_terminator(&case.input)) ==
+                case.expected_tail
             );
             assert!(
-                super::match_line_terminator_sequence(&case.input).map(|(_, tail)| tail) ==
-                case.expected_tail.as_deref()
+                unwrap_tail(super::match_line_terminator_sequence(&case.input)) ==
+                case.expected_tail
             );
         }
     }
@@ -367,8 +367,8 @@ mod tests {
     ) {
         for case in generate_cases("\r\n", separator) {
             assert!(
-                super::match_line_terminator_sequence(&case.input).map(|(_, tail)| tail) ==
-                case.expected_tail.as_deref()
+                unwrap_tail(super::match_line_terminator_sequence(&case.input)) ==
+                case.expected_tail
             );
         }
     }


### PR DESCRIPTION
Move the repetitive code that checks if the parser consumed anything, into a separate function `unwrap_tail`.

- Issue: gh-45