### PR TITLE
gh-76: Automate extraction of the untokenized tail

### DIFF
--- a/src/lexical_grammar.pest
+++ b/src/lexical_grammar.pest
@@ -53,10 +53,14 @@
 //! > prior permission. Title to copyright in this work will at all times remain
 //! > with copyright holders.
 
+Digit = { ASCII_DIGIT }
+
+Tail = { ANY* }
+
 /// A match for <https://262.ecma-international.org/14.0/#prod-DecimalDigit>
 ///
 /// ```plain
 /// DecimalDigit ::
 ///     `0` `1` `2` `3` `4` `5` `6` `7` `8` `9`
 /// ```
-DecimalDigit = { SOI ~ ASCII_DIGIT }
+DecimalDigit = { SOI ~ Digit ~ Tail }


### PR DESCRIPTION
We get no performance penalty for `ANY*`grammar rule in the end of the string. As a result, we can safely turn the unprocessed tail after the first recognized token from manual `&str` fiddling into a part of the grammar goal symbol.

- Issue: gh-76