### PR TITLE
gh-76: Replace manual pest recursive tokens with pest-ast

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -82,8 +82,7 @@ dependencies = [
 [[package]]
 name = "from-pest"
 version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3380d8b4f459e3bb35904036044393332e71d5316be9061d9b545c44b6064db"
+source = "git+https://github.com/pest-parser/ast.git?rev=09255d74#09255d748b63ecd5741cefb5275763323871f898"
 dependencies = [
  "log",
  "pest",
@@ -248,8 +247,7 @@ dependencies = [
 [[package]]
 name = "pest-ast"
 version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40b5ac58ac48a503d1efdcf0ff044b442c07ac4645d179c62d4af79db89f9cda"
+source = "git+https://github.com/pest-parser/ast.git?rev=09255d74#09255d748b63ecd5741cefb5275763323871f898"
 dependencies = [
  "itertools",
  "proc-macro2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -62,13 +62,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "either"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3dca9240753cf90908d7e4aac30f630662b02aebaa1b58a3cadabdb23385b58b"
+
+[[package]]
 name = "embedded-ecmascript"
 version = "0.1.0"
 dependencies = [
+ "from-pest",
  "pest",
+ "pest-ast",
  "pest_derive",
  "rstest",
  "unicode-ident",
+]
+
+[[package]]
+name = "from-pest"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3380d8b4f459e3bb35904036044393332e71d5316be9061d9b545c44b6064db"
+dependencies = [
+ "log",
+ "pest",
+ "void",
 ]
 
 [[package]]
@@ -183,10 +202,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.155"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
+
+[[package]]
+name = "log"
+version = "0.4.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
 
 [[package]]
 name = "memchr"
@@ -209,6 +243,18 @@ dependencies = [
  "memchr",
  "thiserror",
  "ucd-trie",
+]
+
+[[package]]
+name = "pest-ast"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40b5ac58ac48a503d1efdcf0ff044b442c07ac4645d179c62d4af79db89f9cda"
+dependencies = [
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -428,3 +474,9 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "void"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,9 @@ keywords = ["parser", "ecmascript", "javascript", "compiler"]
 categories = ["compilers", "parser-implementations"]
 
 [dependencies]
+from-pest = "0.3.2"
 pest = "2.7.10"
+pest-ast = "0.3.4"
 pest_derive = "2.7.10"
 rstest = "0.18.2"
 unicode-ident = "1.0.12"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,9 +11,12 @@ keywords = ["parser", "ecmascript", "javascript", "compiler"]
 categories = ["compilers", "parser-implementations"]
 
 [dependencies]
-from-pest = "0.3.2"
+# We need <https://github.com/pest-parser/ast/pull/27> fix not available
+# in crates.io yet.
+from-pest = { git = "https://github.com/pest-parser/ast.git", rev = "09255d74" }
 pest = "2.7.10"
-pest-ast = "0.3.4"
+# git key accepts the repo root URL and Cargo traverses the tree to find the crate
+pest-ast = { git = "https://github.com/pest-parser/ast.git", rev = "09255d74" }
 pest_derive = "2.7.10"
 rstest = "0.18.2"
 unicode-ident = "1.0.12"

--- a/src/lexical_grammar.pest
+++ b/src/lexical_grammar.pest
@@ -55,7 +55,7 @@
 
 Digit = { ASCII_DIGIT }
 
-Tail = { ANY* }
+UnprocessedTail = { ANY* }
 
 /// A match for <https://262.ecma-international.org/14.0/#prod-DecimalDigit>
 ///
@@ -63,4 +63,4 @@ Tail = { ANY* }
 /// DecimalDigit ::
 ///     `0` `1` `2` `3` `4` `5` `6` `7` `8` `9`
 /// ```
-DecimalDigit = { SOI ~ Digit ~ Tail }
+DecimalDigit = { SOI ~ Digit ~ UnprocessedTail }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,9 +25,6 @@ pub enum Token {
     NumericLiteral(f64),
 }
 
-// Turning the argument into a reference causes "expected `&Span<'_>`, found
-// `Span<'_>`" error on `#[pest_ast(outer(with(span_into_str)))]`.
-#[allow(clippy::clone_on_copy)]
 fn span_into_str(span: Span) -> &str {
     span.as_str()
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,13 +15,39 @@ mod lexical {
     pub struct Ecma262Parser;
 }
 
-use pest::iterators::Pairs;
-use pest::Parser;
+use from_pest::FromPest;
+use pest::{Parser, Span};
+use pest_ast::FromPest;
 
 /// An output of the tokenization step
 #[derive(Clone, Debug, PartialEq)]
 pub enum Token {
     NumericLiteral(f64),
+}
+
+fn span_into_str(span: Span) -> &str {
+    span.as_str()
+}
+
+#[derive(Debug, FromPest)]
+#[pest_ast(rule(lexical::Rule::Digit))]
+struct Digit {
+    #[pest_ast(outer(with(span_into_str), with(str::parse), with(Result::unwrap)))]
+    pub value: f64
+}
+
+#[derive(Debug, FromPest)]
+#[pest_ast(rule(lexical::Rule::UnprocessedTail))]
+struct UnprocessedTail<'src> {
+     #[pest_ast(outer(with(span_into_str)))]
+    pub content: &'src str,
+}
+
+#[derive(Debug, FromPest)]
+#[pest_ast(rule(lexical::Rule::DecimalDigit))]
+struct DecimalDigit<'src> {
+    pub digit: Digit,
+    pub tail: UnprocessedTail<'src>
 }
 
 /// Extract a first token from a `.js`/`.mjs` text.
@@ -43,24 +69,12 @@ pub enum Token {
 pub fn get_next_token(input: &str) -> Result<(Token, &str), String> {
     let result = lexical::Ecma262Parser::parse(lexical::Rule::DecimalDigit, input);
     match result {
-        Ok(tokens) => Ok(calculate(tokens)),
+        Ok(mut tokens) => {
+            let parsed = DecimalDigit::from_pest(&mut tokens).unwrap();
+            Ok((Token::NumericLiteral(parsed.digit.value), parsed.tail.content))
+        },
         Err(error) => Err(error.to_string())
     }
-}
-
-fn calculate(mut tokens: Pairs<lexical::Rule>) -> (Token, &str) {
-    let root_token = tokens.next().unwrap();
-    let mut subtokens = root_token.into_inner();
-
-    let found = subtokens.next().unwrap();
-    let tail = subtokens.next().unwrap();
-
-    let value = found.as_str();
-    let parsed = match found.as_rule() {
-        lexical::Rule::Digit => Token::NumericLiteral(value.parse::<f64>().unwrap()),
-        lexical::Rule::Tail | lexical::Rule::DecimalDigit => unreachable!(),
-    };
-    (parsed, tail.as_str())
 }
 
 mod _tokenizer;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,6 +25,9 @@ pub enum Token {
     NumericLiteral(f64),
 }
 
+// Turning the argument into a reference causes "expected `&Span<'_>`, found
+// `Span<'_>`" error on `#[pest_ast(outer(with(span_into_str)))]`.
+#[allow(clippy::clone_on_copy)]
 fn span_into_str(span: Span) -> &str {
     span.as_str()
 }


### PR DESCRIPTION
Prepare to nested calculation of literal values mandated by ECMA-262 by replacing manual token pair tree processing with DAO-like pest-ast library.

The library converts the raw tree into a hierarchy of objects by rules described in programmer-supplied macros.

- Issue: gh-76