### PR TITLE
gh-76: De-automate extraction of the untokenized tail

### DIFF
--- a/src/lexical_grammar.pest
+++ b/src/lexical_grammar.pest
@@ -55,13 +55,6 @@
 
 Digit = { ASCII_DIGIT }
 
-/// A match for anything beyond the first token.
-///
-/// Function [get_next_token] recognies one token at a time to allow switching
-/// goal symbols. So the function returns a tuple of a token and the unprocessed
-/// rest (tail) of the input string. 
-UnprocessedTail = { ANY* }
-
 /// A match for <https://262.ecma-international.org/14.0/#prod-DecimalDigit>
 ///
 /// ```plain
@@ -81,4 +74,4 @@ DecimalDigit = { Digit }
 ///     DivPunctuator
 ///     RightBracePunctuator
 /// ```
-InputElementDiv = { SOI ~ DecimalDigit ~ UnprocessedTail }
+InputElementDiv = { SOI ~ DecimalDigit }


### PR DESCRIPTION
*This PR effectively rolls back gh-80.*

A symbol alternative (like A | B | C | ...) in a root symbol of the tokenizer grammar would naturally map to `enum` by pest-ast if not the unparsed tail making the rule into (A | B | ..., tail).

Thus, to get our `enum` we need to either wrap the alternative-only root into another, real root with the tail, or return the out-of-grammar manual tail extraction. The former way does not work with future multi-goal-symbol approach of ECMA-262 so we roll the change back instead.

- Issue: gh-76