### PR TITLE
gh-9: Fix tail extraction attempt on parse error in get_next_token

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,6 +33,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "claims"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6995bbe186456c36307f8ea36be3eefe42f49d106896414e18efc4fb2f846b5"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -71,6 +80,7 @@ checksum = "3dca9240753cf90908d7e4aac30f630662b02aebaa1b58a3cadabdb23385b58b"
 name = "embedded-ecmascript"
 version = "0.1.0"
 dependencies = [
+ "claims",
  "from-pest",
  "pest",
  "pest-ast",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ keywords = ["parser", "ecmascript", "javascript", "compiler"]
 categories = ["compilers", "parser-implementations"]
 
 [dependencies]
+claims = "0.7.1"
 # We need <https://github.com/pest-parser/ast/pull/27> fix not available
 # in crates.io yet.
 from-pest = { git = "https://github.com/pest-parser/ast.git", rev = "09255d74" }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,9 +66,9 @@ struct InputElementDiv {
 /// This means a broken grammar file used by developers to build the parser.
 pub fn get_next_token(input: &str) -> Result<(Token, &str), String> {
     let result = lexical::Ecma262Parser::parse(lexical::Rule::InputElementDiv, input);
-    let tail = get_unprocessed_tail(result.clone().unwrap(), input);
     match result {
         Ok(mut tokens) => {
+            let tail = get_unprocessed_tail(tokens.clone(), input);
             let parsed = InputElementDiv::from_pest(&mut tokens).unwrap();
             Ok((Token::NumericLiteral(parsed.token.digit.value), tail))
         },

--- a/tests/test_tokenizer.rs
+++ b/tests/test_tokenizer.rs
@@ -1,7 +1,13 @@
 #[cfg(test)]
 mod tests {
+    use claims::assert_matches;
     use embedded_ecmascript::{get_next_token, Token};
     use rstest::rstest;
+
+    #[test]
+    fn test_error_infrastructure() {
+        assert_matches!(get_next_token(":"), Err(message) if message.len() > 0);
+    }
 
     #[rstest]
     fn match_decimal_digit(

--- a/tests/test_tokenizer.rs
+++ b/tests/test_tokenizer.rs
@@ -6,7 +6,7 @@ mod tests {
 
     #[test]
     fn test_error_infrastructure() {
-        assert_matches!(get_next_token(":"), Err(message) if message.len() > 0);
+        assert_matches!(get_next_token(":"), Err(message) if !message.is_empty());
     }
 
     #[rstest]


### PR DESCRIPTION
`get_next_token` tries to get the unparsed tail by chopping of a recognized token no matter whether we got the token or a parse error. As a result, the error yields to a panic.

This PR moves the tail extraction into processing of parse success. Also, it adds a regression test that uses `claims` crate.

- Issue: gh-9