### PR TITLE
gh-9: Add more goal symbols as an internal detail

### DIFF
--- a/src/lexical_grammar.pest
+++ b/src/lexical_grammar.pest
@@ -102,6 +102,92 @@ InputElementDiv = {
     )
 }
 
+/// A match for <https://262.ecma-international.org/14.0/#prod-InputElementRegExp>.
+///
+/// ```plain
+/// InputElementRegExp ::
+///     WhiteSpace
+///     LineTerminator
+///     Comment
+///     CommonToken
+///     RightBracePunctuator
+///     RegularExpressionLiteral
+/// ```
+InputElementRegExp = {
+    SOI ~
+    (
+        WhiteSpace |
+        LineTerminator |
+        Comment |
+        CommonToken |
+        RightBracePunctuator
+    )
+}
+
+/// A match for <https://262.ecma-international.org/14.0/#prod-InputElementRegExpOrTemplateTail>.
+///
+/// ```plain
+/// InputElementRegExpOrTemplateTail ::
+///     WhiteSpace
+///     LineTerminator
+///     Comment
+///     3
+///     RegularExpressionLiteral
+///     TemplateSubstitutionTail
+/// ```
+InputElementRegExpOrTemplateTail = {
+    SOI ~
+    (
+        WhiteSpace |
+        LineTerminator |
+        Comment |
+        CommonToken
+    )
+}
+
+/// A match for <https://262.ecma-international.org/14.0/#prod-InputElementTemplateTail>.
+///
+/// ```plain
+/// InputElementTemplateTail ::
+///     WhiteSpace
+///     LineTerminator
+///     Comment
+///     CommonToken
+///     DivPunctuator
+///     TemplateSubstitutionTail
+/// ```
+InputElementTemplateTail = {
+    SOI ~
+    (
+        WhiteSpace |
+        LineTerminator |
+        Comment |
+        CommonToken |
+        DivPunctuator
+    )
+}
+
+/// A match for <https://262.ecma-international.org/14.0/#prod-InputElementHashbangOrRegExp>.
+///
+/// ```plain
+/// InputElementHashbangOrRegExp ::
+///     WhiteSpace
+///     LineTerminator
+///     Comment
+///     CommonToken
+///     HashbangComment
+///     RegularExpressionLiteral
+///     InputElementDiv
+/// ```
+InputElementHashbangOrRegExp = {
+    SOI ~
+    (
+        WhiteSpace |
+        LineTerminator |
+        Comment
+    )
+}
+
 /************************************************
  *
  * 12.1 Unicode Format-Control Characters

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -736,10 +736,10 @@ enum InputElementHashbangOrRegExp {
 // InputElementRegExp, and InputElementRegExpOrTemplateTail
 #[allow(dead_code)]
 enum PackedToken {
-    InputElementDiv(InputElementDiv),
-    InputElementHashbangOrRegExp(InputElementHashbangOrRegExp),
-    InputElementRegExp(InputElementRegExp),
-    InputElementRegExpOrTemplateTail(InputElementRegExpOrTemplateTail),
+    Div(InputElementDiv),
+    HashbangOrRegExp(InputElementHashbangOrRegExp),
+    RegExp(InputElementRegExp),
+    RegExpOrTemplateTail(InputElementRegExpOrTemplateTail),
 }
 
 enum UnpackedToken {
@@ -775,7 +775,7 @@ pub fn get_next_token(input: &str) -> Result<(Token, &str), String> {
         Ok(mut tokens) => {
             let tail = get_unprocessed_tail(tokens.clone(), input);
             let parsed = InputElementDiv::from_pest(&mut tokens).unwrap();
-            let plain = unpack_token(PackedToken::InputElementDiv(parsed));
+            let plain = unpack_token(PackedToken::Div(parsed));
             Ok((flatten_token(plain), tail))
         },
         Err(error) => Err(error.to_string())
@@ -784,7 +784,7 @@ pub fn get_next_token(input: &str) -> Result<(Token, &str), String> {
 
 fn unpack_token(input: PackedToken) -> UnpackedToken {
     match input {
-        PackedToken::InputElementDiv(root) => {
+        PackedToken::Div(root) => {
             match root {
                 InputElementDiv::WhiteSpace(item) => UnpackedToken::WhiteSpace(item),
                 InputElementDiv::LineTerminator(item) => UnpackedToken::LineTerminator(item),
@@ -796,14 +796,14 @@ fn unpack_token(input: PackedToken) -> UnpackedToken {
                 InputElementDiv::DecimalDigit(item) => UnpackedToken::DecimalDigit(item),
             }
         },
-        PackedToken::InputElementHashbangOrRegExp(root) => {
+        PackedToken::HashbangOrRegExp(root) => {
             match root {
                 InputElementHashbangOrRegExp::WhiteSpace(item) => UnpackedToken::WhiteSpace(item),
                 InputElementHashbangOrRegExp::LineTerminator(item) => UnpackedToken::LineTerminator(item),
                 InputElementHashbangOrRegExp::Comment(item) => UnpackedToken::Comment(item),
             }
         },
-        PackedToken::InputElementRegExp(root) => {
+        PackedToken::RegExp(root) => {
             match root {
                 InputElementRegExp::WhiteSpace(item) => UnpackedToken::WhiteSpace(item),
                 InputElementRegExp::LineTerminator(item) => UnpackedToken::LineTerminator(item),
@@ -812,7 +812,7 @@ fn unpack_token(input: PackedToken) -> UnpackedToken {
                 InputElementRegExp::RightBracePunctuator(item) => UnpackedToken::RightBracePunctuator(item),
             }
         },
-        PackedToken::InputElementRegExpOrTemplateTail(root) => {
+        PackedToken::RegExpOrTemplateTail(root) => {
             match root {
                 InputElementRegExpOrTemplateTail::WhiteSpace(item) => UnpackedToken::WhiteSpace(item),
                 InputElementRegExpOrTemplateTail::LineTerminator(item) => UnpackedToken::LineTerminator(item),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -732,6 +732,9 @@ enum InputElementHashbangOrRegExp {
     Comment(Comment),
 }
 
+// Remove after we start processing InputElementHashbangOrRegExp,
+// InputElementRegExp, and InputElementRegExpOrTemplateTail
+#[allow(dead_code)]
 enum PackedToken {
     InputElementDiv(InputElementDiv),
     InputElementHashbangOrRegExp(InputElementHashbangOrRegExp),


### PR DESCRIPTION
Prepare the parser for exposure of `InputElementRegExp`, `InputElementRegExpOrTemplateTail`, and `InputElementHashbangOrRegExp` extra goal symbols by implementing the unified logic of processing them all.

Since all goal symbols mostly share non-terminals on their right side, we can create a enum listing all possible right-side non-terminals. It allows us to write a per-goal logic copying into the unified enum and slightly modify existing `extract_token` to make it a shared processor of the unified enum.
 
For more details and the ultimate purpose, see description of `GoalSymbols` in the parent issue.

- Issue: gh-9