### PR TITLE
gh-9: Add ReservedWord everywhere after CommonToken

### DIFF
--- a/src/lexical_grammar.pest
+++ b/src/lexical_grammar.pest
@@ -94,8 +94,11 @@ InputElementDiv = {
         WhiteSpace |
         LineTerminator |
         Comment |
-        ReservedWord |
-        CommonToken |
+        // <https://262.ecma-international.org/14.0/#sec-names-and-keywords>:
+        //
+        // > The syntactic grammar defines Identifier as an IdentifierName that
+        // > is not a ReservedWord.
+        ReservedWord | CommonToken |
         DivPunctuator |
         RightBracePunctuator |
         DecimalDigit
@@ -119,7 +122,11 @@ InputElementRegExp = {
         WhiteSpace |
         LineTerminator |
         Comment |
-        CommonToken |
+        // <https://262.ecma-international.org/14.0/#sec-names-and-keywords>:
+        //
+        // > The syntactic grammar defines Identifier as an IdentifierName that
+        // > is not a ReservedWord.
+        ReservedWord | CommonToken |
         RightBracePunctuator
     )
 }
@@ -131,7 +138,7 @@ InputElementRegExp = {
 ///     WhiteSpace
 ///     LineTerminator
 ///     Comment
-///     3
+///     CommonToken
 ///     RegularExpressionLiteral
 ///     TemplateSubstitutionTail
 /// ```
@@ -141,7 +148,11 @@ InputElementRegExpOrTemplateTail = {
         WhiteSpace |
         LineTerminator |
         Comment |
-        CommonToken
+        // <https://262.ecma-international.org/14.0/#sec-names-and-keywords>:
+        //
+        // > The syntactic grammar defines Identifier as an IdentifierName that
+        // > is not a ReservedWord.
+        ReservedWord | CommonToken
     )
 }
 
@@ -162,7 +173,11 @@ InputElementTemplateTail = {
         WhiteSpace |
         LineTerminator |
         Comment |
-        CommonToken |
+        // <https://262.ecma-international.org/14.0/#sec-names-and-keywords>:
+        //
+        // > The syntactic grammar defines Identifier as an IdentifierName that
+        // > is not a ReservedWord.
+        ReservedWord | CommonToken |
         DivPunctuator
     )
 }
@@ -184,7 +199,12 @@ InputElementHashbangOrRegExp = {
     (
         WhiteSpace |
         LineTerminator |
-        Comment
+        Comment |
+        // <https://262.ecma-international.org/14.0/#sec-names-and-keywords>:
+        //
+        // > The syntactic grammar defines Identifier as an IdentifierName that
+        // > is not a ReservedWord.
+        ReservedWord | CommonToken
     )
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -711,6 +711,7 @@ enum InputElementRegExp {
     LineTerminator(LineTerminator),
     Comment(Comment),
     CommonToken(CommonToken),
+    ReservedWord(ReservedWord),
     RightBracePunctuator(RightBracePunctuator),
 }
 
@@ -722,6 +723,7 @@ enum InputElementRegExpOrTemplateTail {
     Comment(Comment),
     CommonToken(CommonToken),
     DivPunctuator(DivPunctuator),
+    ReservedWord(ReservedWord),
 }
 
 #[derive(Debug, FromPest)]
@@ -730,6 +732,8 @@ enum InputElementHashbangOrRegExp {
     WhiteSpace(WhiteSpace),
     LineTerminator(LineTerminator),
     Comment(Comment),
+    CommonToken(CommonToken),
+    ReservedWord(ReservedWord),
 }
 
 // Remove after we start processing InputElementHashbangOrRegExp,
@@ -801,6 +805,8 @@ fn unpack_token(input: PackedToken) -> UnpackedToken {
                 InputElementHashbangOrRegExp::WhiteSpace(item) => UnpackedToken::WhiteSpace(item),
                 InputElementHashbangOrRegExp::LineTerminator(item) => UnpackedToken::LineTerminator(item),
                 InputElementHashbangOrRegExp::Comment(item) => UnpackedToken::Comment(item),
+                InputElementHashbangOrRegExp::CommonToken(item) => UnpackedToken::CommonToken(item),
+                InputElementHashbangOrRegExp::ReservedWord(item) => UnpackedToken::ReservedWord(item),
             }
         },
         PackedToken::RegExp(root) => {
@@ -809,6 +815,7 @@ fn unpack_token(input: PackedToken) -> UnpackedToken {
                 InputElementRegExp::LineTerminator(item) => UnpackedToken::LineTerminator(item),
                 InputElementRegExp::Comment(item) => UnpackedToken::Comment(item),
                 InputElementRegExp::CommonToken(item) => UnpackedToken::CommonToken(item),
+                InputElementRegExp::ReservedWord(item) => UnpackedToken::ReservedWord(item),
                 InputElementRegExp::RightBracePunctuator(item) => UnpackedToken::RightBracePunctuator(item),
             }
         },
@@ -819,6 +826,7 @@ fn unpack_token(input: PackedToken) -> UnpackedToken {
                 InputElementRegExpOrTemplateTail::Comment(item) => UnpackedToken::Comment(item),
                 InputElementRegExpOrTemplateTail::CommonToken(item) => UnpackedToken::CommonToken(item),
                 InputElementRegExpOrTemplateTail::DivPunctuator(item) => UnpackedToken::DivPunctuator(item),
+                InputElementRegExpOrTemplateTail::ReservedWord(item) => UnpackedToken::ReservedWord(item),
             }
         },
     }


### PR DESCRIPTION
According to the ECMASccript specification, ReservedWord always follows IdentifierName (included in CommonToken) in grammar definition (<https://262.ecma-international.org/14.0/#sec-names-and-keywords>):

> The syntactic grammar defines Identifier as an IdentifierName that
> is not a ReservedWord.

So we make every goal symbol supporting CommonToken into supporting ReservedWord as well.

- Issue: gh-9