### PR TITLE
gh-18: Remove provisional pseudo-DecimalDigit

### DIFF
--- a/src/lexical_grammar.pest
+++ b/src/lexical_grammar.pest
@@ -53,22 +53,6 @@
 //! > prior permission. Title to copyright in this work will at all times remain
 //! > with copyright holders.
 
-Digit = { ASCII_DIGIT }
-
-/************************************************
- *
- * 12 ECMAScript Language: Lexical Grammar
- *
- ************************************************/
-
-/// A match for <https://262.ecma-international.org/14.0/#prod-DecimalDigit>
-///
-/// ```plain
-/// DecimalDigit ::
-///     `0` `1` `2` `3` `4` `5` `6` `7` `8` `9`
-/// ```
-DecimalDigit = { Digit }
-
 /************************************************
  *
  * 12 ECMAScript Language: Lexical Grammar
@@ -100,8 +84,7 @@ InputElementDiv = {
         // > is not a ReservedWord.
         ReservedWord | CommonToken |
         DivPunctuator |
-        RightBracePunctuator |
-        DecimalDigit
+        RightBracePunctuator
     )
 }
 
@@ -799,3 +782,17 @@ DivPunctuator = { DivisionAssignment | Division }
 ///
 /// Implements <https://262.ecma-international.org/14.0/#prod-RightBracePunctuator>.
 RightBracePunctuator = { "}" }
+
+/************************************************
+ *
+ * 12.9.3 Numeric Literals
+ *
+ ************************************************/
+
+/// A match for <https://262.ecma-international.org/14.0/#prod-DecimalDigit>
+///
+/// ```plain
+/// DecimalDigit ::
+///     `0` `1` `2` `3` `4` `5` `6` `7` `8` `9`
+/// ```
+DecimalDigit = { ASCII_DIGIT }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,7 +63,7 @@ pub enum Keyword {
 }
 
 /// An output of the tokenization step
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum Token {
     WhiteSpace,
     LineTerminator,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -129,7 +129,6 @@ pub enum Token {
     UnsignedRightShiftAssignment,
 
     IdentifierName(String),
-    NumericLiteral(f64),
     PrivateIdentifier(String),
     ReservedWord(Keyword),
 }
@@ -170,19 +169,6 @@ pub enum GoalSymbols {
 
 fn span_into_str(span: Span) -> &str {
     span.as_str()
-}
-
-#[derive(Debug, FromPest)]
-#[pest_ast(rule(lexical::Rule::Digit))]
-struct Digit {
-    #[pest_ast(outer(with(span_into_str), with(str::parse), with(Result::unwrap)))]
-    pub value: f64
-}
-
-#[derive(Debug, FromPest)]
-#[pest_ast(rule(lexical::Rule::DecimalDigit))]
-struct DecimalDigit {
-    pub digit: Digit,
 }
 
 #[derive(Debug, FromPest)]
@@ -743,7 +729,6 @@ enum InputElementDiv {
     DivPunctuator(DivPunctuator),
     ReservedWord(ReservedWord),
     RightBracePunctuator(RightBracePunctuator),
-    DecimalDigit(DecimalDigit),
 }
 
 #[derive(Debug, FromPest)]
@@ -801,7 +786,6 @@ enum PackedToken<'src> {
 enum UnpackedToken<'src> {
     Comment(Comment),
     CommonToken(CommonToken),
-    DecimalDigit(DecimalDigit),
     DivPunctuator(DivPunctuator),
     HashbangComment(HashbangComment<'src>),
     LineTerminator(LineTerminator),
@@ -877,7 +861,6 @@ fn unpack_token(input: PackedToken<'_>) -> UnpackedToken<'_> {
                 InputElementDiv::DivPunctuator(item) => UnpackedToken::DivPunctuator(item),
                 InputElementDiv::ReservedWord(item) => UnpackedToken::ReservedWord(item),
                 InputElementDiv::RightBracePunctuator(item) => UnpackedToken::RightBracePunctuator(item),
-                InputElementDiv::DecimalDigit(item) => UnpackedToken::DecimalDigit(item),
             }
         },
         PackedToken::HashbangOrRegExp(root) => {
@@ -925,7 +908,6 @@ fn unpack_token(input: PackedToken<'_>) -> UnpackedToken<'_> {
 
 fn flatten_token(symbol_tree: UnpackedToken) -> Token {
     match symbol_tree {
-        UnpackedToken::DecimalDigit(value) => Token::NumericLiteral(value.digit.value),
         UnpackedToken::WhiteSpace(_) => Token::WhiteSpace,
         UnpackedToken::Comment(kind) => {
             match kind {

--- a/tests/test_tokenizer.rs
+++ b/tests/test_tokenizer.rs
@@ -317,26 +317,6 @@ mod tests {
     }
 
     #[rstest]
-    fn match_decimal_digit(
-        #[values("0", "1", "2", "3", "4", "5", "6", "7", "8", "9")]
-        tested: &str,
-    ) {
-        let parsed = Token::NumericLiteral(tested.parse().unwrap());
-
-        assert_ok_eq!(
-            get_next_token(tested, GoalSymbols::InputElementDiv),
-            (parsed.clone(), "")
-        );
-
-        let tail = " ".to_owned() + tested;
-        let with_tail = tested.to_owned() + &tail;
-        assert_ok_eq!(
-            get_next_token(&with_tail, GoalSymbols::InputElementDiv),
-            (parsed, tail.as_str())
-        );
-    }
-
-    #[rstest]
     fn test_multiline_comments(
         #[values(
             GoalSymbols::InputElementHashbangOrRegExp,


### PR DESCRIPTION
This non-terminal was a placeholder when we started the grammar. Now we have full-fledged non-terminal hierarchy so remove this bootstrap.

Instead, we introduce a proper declaration of DecimalDigit how specified in the specification.

- Issue: gh-18