### PR TITLE
gh-115: Add IdentifierName.IdentifierCodePoints

### DIFF
--- a/src/lexical_grammar.rs
+++ b/src/lexical_grammar.rs
@@ -100,7 +100,7 @@ pub struct PrivateIdentifier {
     pub payload: IdentifierName
 }
 
-#[derive(Debug, FromPest, Eq, PartialEq)]
+#[derive(Debug, Eq, FromPest, PartialEq)]
 #[pest_ast(rule(Rule::IdentifierName))]
 pub struct IdentifierName {
     // Escape sequence decoding do not allow to use `&str`

--- a/src/lexical_grammar.rs
+++ b/src/lexical_grammar.rs
@@ -1,7 +1,25 @@
 //! ORM for tokenizer of `.js` and `.mjs` files.
 //!
-//! Supplements the weakly typed span-based tokenizer generated from
-//! `lexical_grammar.pest` with strongly typed tree of pub structs.
+//! Supplements the tokenizer by repacking weakly typed span-based parse tree
+//! into the strongly typed struct-per-nonterminal parse tree.
+//!
+//! Each strongly typed parse tree node has a few methods specified by ECMA-262.
+//! These methods, called semantics, calculate values and perform checks. From
+//! <https://262.ecma-international.org/14.0/#sec-static-semantic-rules>:
+//!
+//! > Context-free grammars are not sufficiently powerful to express all
+//! > the rules that define whether a stream of input elements form a valid
+//! > ECMAScript Script or Module that may be evaluated. In some situations
+//! > additional rules are needed that may be expressed using either ECMAScript
+//! > algorithm conventions or prose requirements. Such rules are always
+//! > associated with a production of a grammar and are called the static
+//! > semantics of the production.
+//! >
+//! > Static Semantic Rules have names and typically are defined using
+//! > an algorithm. Named Static Semantic Rules are associated with grammar
+//! > productions and a production that has multiple alternative definitions
+//! > will typically have for each alternative a distinct algorithm for each
+//! > applicable named static semantic rule.
 //!
 //! Implements <https://262.ecma-international.org/14.0/#sec-ecmascript-language-lexical-grammar>.
 //!
@@ -82,12 +100,18 @@ pub struct PrivateIdentifier {
     pub payload: IdentifierName
 }
 
-#[derive(Debug, FromPest)]
+#[derive(Debug, FromPest, Eq, PartialEq)]
 #[pest_ast(rule(Rule::IdentifierName))]
 pub struct IdentifierName {
     // Escape sequence decoding do not allow to use `&str`
     #[pest_ast(outer(with(span_into_str), with(str::to_string)))]
-    pub decoded: String
+    decoded: String
+}
+
+impl IdentifierName {
+    pub fn string_value(&self) -> String {
+        self.decoded.clone()
+    }
 }
 
 #[derive(Debug, FromPest)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@
 mod lexical_grammar;
 
 use from_pest::FromPest;
-use lexical_grammar::{Comment, CommonToken, DivPunctuator, Ecma262Parser, HashbangComment, InputElementDiv, InputElementHashbangOrRegExp, InputElementRegExp, InputElementRegExpOrTemplateTail, InputElementTemplateTail, LineTerminator, OtherPunctuator, Punctuator, ReservedWord, RightBracePunctuator, Rule, WhiteSpace};
+use lexical_grammar::{Comment, CommonToken, DivPunctuator, Ecma262Parser, HashbangComment, IdentifierName, InputElementDiv, InputElementHashbangOrRegExp, InputElementRegExp, InputElementRegExpOrTemplateTail, InputElementTemplateTail, LineTerminator, OtherPunctuator, Punctuator, ReservedWord, RightBracePunctuator, Rule, WhiteSpace};
 use pest::{iterators::Pairs, Parser};
 
 /// A keyword; may be used as a name in some cases.
@@ -57,7 +57,7 @@ pub enum Keyword {
 }
 
 /// An output of the tokenization step
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Debug, Eq, PartialEq)]
 pub enum Token {
     WhiteSpace,
     LineTerminator,
@@ -122,7 +122,7 @@ pub enum Token {
     UnsignedRightShift,
     UnsignedRightShiftAssignment,
 
-    IdentifierName(String),
+    IdentifierName(IdentifierName),
     PrivateIdentifier(String),
     ReservedWord(Keyword),
 }
@@ -305,8 +305,8 @@ fn flatten_token(symbol_tree: UnpackedToken) -> Token {
         },
         UnpackedToken::CommonToken(token) => {
             match token {
-                CommonToken::IdentifierName(name) => Token::IdentifierName(name.decoded),
-                CommonToken::PrivateIdentifier(name) => Token::PrivateIdentifier(name.payload.decoded),
+                CommonToken::IdentifierName(name) => Token::IdentifierName(name),
+                CommonToken::PrivateIdentifier(name) => Token::PrivateIdentifier(name.payload.string_value()),
                 CommonToken::Punctuator(punctuator) => {
                     match punctuator {
                         Punctuator::OptionalChainingPunctuator(_) => Token::OptionalChaining,

--- a/tests/test_tokenizer.rs
+++ b/tests/test_tokenizer.rs
@@ -86,14 +86,14 @@ mod tests {
         )]
         mode: GoalSymbols,
     ) {
-        assert_ok_eq!(
+        assert_matches!(
             get_next_token(tested, mode),
-            (Token::IdentifierName(tested.to_owned()), "")
+            Ok((Token::IdentifierName(name), "")) if name.string_value() == tested
         );
         let doubled = tested.to_owned() + tested;
-        assert_ok_eq!(
+        assert_matches!(
             get_next_token(&doubled, mode),
-            (Token::IdentifierName(doubled.clone()), "")
+            Ok((Token::IdentifierName(name), "")) if name.string_value() == doubled
         );
 
         let private = "#".to_owned() + tested;


### PR DESCRIPTION
Start the conversion from parse-time flattening to ECMA-262 static semantics with pseudo-IdentifierName semantic for IdentifierName production.

"Pseudo" means "no recurrent calls into child non-terminals as described by the specification".

- Issue: gh-115