### PR TITLE
gh-115: Add PrivateIdentifier.StringValue

### DIFF
--- a/src/lexical_grammar.rs
+++ b/src/lexical_grammar.rs
@@ -94,10 +94,19 @@ pub struct WhiteSpace;
 #[pest_ast(rule(Rule::LineTerminator))]
 pub struct LineTerminator;
 
-#[derive(Debug, FromPest)]
+#[derive(Debug, Eq, FromPest, PartialEq)]
 #[pest_ast(rule(Rule::PrivateIdentifier))]
 pub struct PrivateIdentifier {
-    pub payload: IdentifierName
+    identifier_name: IdentifierName
+}
+
+impl PrivateIdentifier {
+    /// <https://262.ecma-international.org/14.0/#sec-static-semantics-stringvalue>
+    pub fn string_value(&self) -> String {
+        // 1. Return the string-concatenation of 0x0023 (NUMBER SIGN) and
+        //    the StringValue of IdentifierName.
+        "#".to_owned() + &self.identifier_name.string_value()
+    }
 }
 
 #[derive(Debug, Eq, FromPest, PartialEq)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@
 mod lexical_grammar;
 
 use from_pest::FromPest;
-use lexical_grammar::{Comment, CommonToken, DivPunctuator, Ecma262Parser, HashbangComment, IdentifierName, InputElementDiv, InputElementHashbangOrRegExp, InputElementRegExp, InputElementRegExpOrTemplateTail, InputElementTemplateTail, LineTerminator, OtherPunctuator, Punctuator, ReservedWord, RightBracePunctuator, Rule, WhiteSpace};
+use lexical_grammar::{Comment, CommonToken, DivPunctuator, Ecma262Parser, HashbangComment, IdentifierName, InputElementDiv, InputElementHashbangOrRegExp, InputElementRegExp, InputElementRegExpOrTemplateTail, InputElementTemplateTail, LineTerminator, OtherPunctuator, PrivateIdentifier, Punctuator, ReservedWord, RightBracePunctuator, Rule, WhiteSpace};
 use pest::{iterators::Pairs, Parser};
 
 /// A keyword; may be used as a name in some cases.
@@ -123,7 +123,7 @@ pub enum Token {
     UnsignedRightShiftAssignment,
 
     IdentifierName(IdentifierName),
-    PrivateIdentifier(String),
+    PrivateIdentifier(PrivateIdentifier),
     ReservedWord(Keyword),
 }
 
@@ -306,7 +306,7 @@ fn flatten_token(symbol_tree: UnpackedToken) -> Token {
         UnpackedToken::CommonToken(token) => {
             match token {
                 CommonToken::IdentifierName(name) => Token::IdentifierName(name),
-                CommonToken::PrivateIdentifier(name) => Token::PrivateIdentifier(name.payload.string_value()),
+                CommonToken::PrivateIdentifier(name) => Token::PrivateIdentifier(name),
                 CommonToken::Punctuator(punctuator) => {
                     match punctuator {
                         Punctuator::OptionalChainingPunctuator(_) => Token::OptionalChaining,

--- a/tests/test_tokenizer.rs
+++ b/tests/test_tokenizer.rs
@@ -97,14 +97,14 @@ mod tests {
         );
 
         let private = "#".to_owned() + tested;
-        assert_ok_eq!(
+        assert_matches!(
             get_next_token(&private, mode),
-            (Token::PrivateIdentifier(tested.to_owned()), "")
+            Ok((Token::PrivateIdentifier(name), "")) if name.string_value() == private
         );
         let doubled_private = private + tested;
-        assert_ok_eq!(
+        assert_matches!(
             get_next_token(&doubled_private, mode),
-            (Token::PrivateIdentifier(doubled), "")
+            Ok((Token::PrivateIdentifier(name), "")) if name.string_value() == doubled_private
         );
     }
 


### PR DESCRIPTION
Continue the conversion from parse-time flattening to ECMA-262 static semantics with IdentifierName semantic for PrivateIdentifier production.

Note that the specification describes the new PrivateIdentifier.StringValue as returning a name with a hash sign while our older implementation returned just a name.

- Issue: gh-115