### PR TITLE
gh-115: Promote Comment into Token

### DIFF
--- a/src/lexical_grammar.rs
+++ b/src/lexical_grammar.rs
@@ -626,18 +626,18 @@ pub enum DivPunctuator {
     Division(Division),
 }
 
-#[derive(Debug, FromPest)]
+#[derive(Debug, Eq, FromPest, PartialEq)]
 #[pest_ast(rule(Rule::Comment))]
 pub enum Comment {
     MultiLineComment(MultiLineComment),
     SingleLineComment(SingleLineComment),
 }
 
-#[derive(Debug, FromPest)]
+#[derive(Debug, Eq, FromPest, PartialEq)]
 #[pest_ast(rule(Rule::MultiLineComment))]
 pub struct MultiLineComment;
 
-#[derive(Debug, FromPest)]
+#[derive(Debug, Eq, FromPest, PartialEq)]
 #[pest_ast(rule(Rule::SingleLineComment))]
 pub struct SingleLineComment;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,7 @@ use pest::{iterators::Pairs, Parser};
 pub enum Token<'src> {
     WhiteSpace,
     LineTerminator,
-    Comment,
+    Comment(Comment),
     HashbangComment(HashbangComment<'src>),
 
     Addition,
@@ -252,11 +252,7 @@ fn unpack_token(input: PackedToken<'_>) -> UnpackedToken<'_> {
 fn flatten_token(symbol_tree: UnpackedToken) -> Token {
     match symbol_tree {
         UnpackedToken::WhiteSpace(_) => Token::WhiteSpace,
-        UnpackedToken::Comment(kind) => {
-            match kind {
-                Comment::MultiLineComment(_) | Comment::SingleLineComment(_) => Token::Comment
-            }
-        },
+        UnpackedToken::Comment(kind) => Token::Comment(kind),
         UnpackedToken::HashbangComment(line) => Token::HashbangComment(line),
         UnpackedToken::CommonToken(token) => {
             match token {

--- a/tests/test_tokenizer.rs
+++ b/tests/test_tokenizer.rs
@@ -327,11 +327,11 @@ mod tests {
         )]
         mode: GoalSymbols,
     ) {
-        assert_ok_eq!(get_next_token("/**/", mode), (Token::Comment, ""));
-        assert_ok_eq!(get_next_token("/* */", mode), (Token::Comment, ""));
-        assert_ok_eq!(get_next_token("/*foo*/", mode), (Token::Comment, ""));
-        assert_ok_eq!(get_next_token("/*/**/", mode), (Token::Comment, ""));
-        assert_ok_eq!(get_next_token("/*\n/*\n*/", mode), (Token::Comment, ""));
+        assert_matches!(get_next_token("/**/", mode), Ok((Token::Comment(_), "")));
+        assert_matches!(get_next_token("/* */", mode), Ok((Token::Comment(_), "")));
+        assert_matches!(get_next_token("/*foo*/", mode), Ok((Token::Comment(_), "")));
+        assert_matches!(get_next_token("/*/**/", mode), Ok((Token::Comment(_), "")));
+        assert_matches!(get_next_token("/*\n/*\n*/", mode), Ok((Token::Comment(_), "")));
     }
 
     #[rstest]
@@ -345,11 +345,11 @@ mod tests {
         )]
         mode: GoalSymbols,
     ) {
-        assert_ok_eq!(get_next_token("//a b", mode), (Token::Comment, ""));
-        assert_ok_eq!(get_next_token("//a b\n", mode), (Token::Comment, "\n"));
-        assert_ok_eq!(
+        assert_matches!(get_next_token("//a b", mode), Ok((Token::Comment(_), "")));
+        assert_matches!(get_next_token("//a b\n", mode), Ok((Token::Comment(_), "\n")));
+        assert_matches!(
             get_next_token("//a b\n//c", mode),
-            (Token::Comment, "\n//c")
+            Ok((Token::Comment(_), "\n//c"))
         );
     }
 


### PR DESCRIPTION
Comment has no static semantics but gets the same treatment replacing a Token enum entry returned by get_next_token.

- Issue: gh-115