### PR TITLE
gh-115: Promote DivPunctuator into Token

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,8 +23,7 @@ pub enum Token<'src> {
 
     CommonToken(CommonToken),
     ClosingBrace,
-    Division,
-    DivisionAssignment,
+    DivPunctuator(DivPunctuator),
 
     IdentifierName(IdentifierName),
     PrivateIdentifier(PrivateIdentifier),
@@ -202,12 +201,7 @@ fn flatten_token(symbol_tree: UnpackedToken) -> Token {
         UnpackedToken::Comment(kind) => Token::Comment(kind),
         UnpackedToken::HashbangComment(line) => Token::HashbangComment(line),
         UnpackedToken::CommonToken(token) => Token::CommonToken(token),
-        UnpackedToken::DivPunctuator(punctuator) => {
-            match punctuator {
-                DivPunctuator::DivisionAssignment(_) => Token::DivisionAssignment,
-                DivPunctuator::Division(_) => Token::Division,
-            }
-        },
+        UnpackedToken::DivPunctuator(punctuator) => Token::DivPunctuator(punctuator),
         UnpackedToken::ReservedWord(keyword) => Token::ReservedWord(keyword),
         UnpackedToken::RightBracePunctuator(_) => Token::ClosingBrace,
         UnpackedToken::LineTerminator(_) => Token::LineTerminator,

--- a/tests/test_tokenizer.rs
+++ b/tests/test_tokenizer.rs
@@ -23,6 +23,9 @@ mod tests {
             Comma,
             CommonToken,
             Decrement,
+            Division,
+            DivisionAssignment,
+            DivPunctuator,
             Dot,
             Ellipsis,
             Exponentiation,
@@ -236,14 +239,14 @@ mod tests {
     fn test_input_element_div_onechar_punctuators() {
         assert_ok_eq!(
             get_next_token("/", GoalSymbols::InputElementDiv),
-            (Token::Division, "")
+            (Token::DivPunctuator(DivPunctuator::Division(Division)), "")
         );
         assert_err!(get_next_token("/", GoalSymbols::InputElementHashbangOrRegExp));
         assert_err!(get_next_token("/", GoalSymbols::InputElementRegExpOrTemplateTail));
         assert_err!(get_next_token("/", GoalSymbols::InputElementRegExp));
         assert_ok_eq!(
             get_next_token("/", GoalSymbols::InputElementTemplateTail),
-            (Token::Division, "")
+            (Token::DivPunctuator(DivPunctuator::Division(Division)), "")
         );
 
         assert_ok_eq!(
@@ -310,14 +313,14 @@ mod tests {
     fn test_input_element_div_twochar_punctuators() {
         assert_ok_eq!(
             get_next_token("/=", GoalSymbols::InputElementDiv),
-            (Token::DivisionAssignment, "")
+            (Token::DivPunctuator(DivPunctuator::DivisionAssignment(DivisionAssignment)), "")
         );
         assert_err!(get_next_token("/=", GoalSymbols::InputElementHashbangOrRegExp));
         assert_err!(get_next_token("/=", GoalSymbols::InputElementRegExpOrTemplateTail));
         assert_err!(get_next_token("/=", GoalSymbols::InputElementRegExp));
         assert_ok_eq!(
             get_next_token("/=", GoalSymbols::InputElementTemplateTail),
-            (Token::DivisionAssignment, "")
+            (Token::DivPunctuator(DivPunctuator::DivisionAssignment(DivisionAssignment)), "")
         );
     }
 


### PR DESCRIPTION
DivPunctuator has no static semantics but gets the same treatment replacing a Token enum entry returned by get_next_token.

- Issue: gh-115