### PR TITLE
gh-115: Merge Token and UnpackedToken

### DIFF
--- a/src/lexical_grammar.rs
+++ b/src/lexical_grammar.rs
@@ -86,11 +86,11 @@ fn span_into_str(span: Span) -> &str {
 #[grammar = "lexical_grammar.pest"]
 pub struct Ecma262Parser;
 
-#[derive(Debug, FromPest)]
+#[derive(Debug, Eq, FromPest, PartialEq)]
 #[pest_ast(rule(Rule::WhiteSpace))]
 pub struct WhiteSpace;
 
-#[derive(Debug, FromPest)]
+#[derive(Debug, Eq, FromPest, PartialEq)]
 #[pest_ast(rule(Rule::LineTerminator))]
 pub struct LineTerminator;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,19 +13,6 @@ use from_pest::FromPest;
 use lexical_grammar::{Comment, CommonToken, DivPunctuator, Ecma262Parser, HashbangComment, IdentifierName, InputElementDiv, InputElementHashbangOrRegExp, InputElementRegExp, InputElementRegExpOrTemplateTail, InputElementTemplateTail, PrivateIdentifier, ReservedWord, Rule};
 use pest::{iterators::Pairs, Parser};
 
-/// An output of the tokenization step
-#[derive(Debug, Eq, PartialEq)]
-pub enum UnpackedToken<'src> {
-    Comment(Comment),
-    CommonToken(CommonToken),
-    DivPunctuator(DivPunctuator),
-    HashbangComment(HashbangComment<'src>),
-    LineTerminator(LineTerminator),
-    ReservedWord(ReservedWord),
-    RightBracePunctuator(RightBracePunctuator),
-    WhiteSpace(WhiteSpace),
-}
-
 /// Kind of a grammar used for tokenization.
 ///
 /// From <https://262.ecma-international.org/14.0/#sec-ecmascript-language-lexical-grammar>:
@@ -66,6 +53,19 @@ enum PackedToken<'src> {
     RegExp(InputElementRegExp),
     RegExpOrTemplateTail(InputElementRegExpOrTemplateTail),
     TemplateTail(InputElementTemplateTail),
+}
+
+/// An output of the tokenization step
+#[derive(Debug, Eq, PartialEq)]
+pub enum UnpackedToken<'src> {
+    Comment(Comment),
+    CommonToken(CommonToken),
+    DivPunctuator(DivPunctuator),
+    HashbangComment(HashbangComment<'src>),
+    LineTerminator(LineTerminator),
+    ReservedWord(ReservedWord),
+    RightBracePunctuator(RightBracePunctuator),
+    WhiteSpace(WhiteSpace),
 }
 
 /// Extract a first token from a `.js`/`.mjs` text.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,8 @@ use from_pest::FromPest;
 use lexical_grammar::{Comment, CommonToken, DivPunctuator, Ecma262Parser, HashbangComment, InputElementDiv, InputElementHashbangOrRegExp, InputElementRegExp, InputElementRegExpOrTemplateTail, InputElementTemplateTail, LineTerminator, ReservedWord, RightBracePunctuator, Rule, WhiteSpace};
 use pest::{iterators::Pairs, Parser};
 
+pub type Token<'src> = UnpackedToken<'src>;
+
 /// Kind of a grammar used for tokenization.
 ///
 /// From <https://262.ecma-international.org/14.0/#sec-ecmascript-language-lexical-grammar>:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@
 pub mod lexical_grammar;
 
 use from_pest::FromPest;
-use lexical_grammar::{Comment, CommonToken, DivPunctuator, Ecma262Parser, HashbangComment, IdentifierName, InputElementDiv, InputElementHashbangOrRegExp, InputElementRegExp, InputElementRegExpOrTemplateTail, InputElementTemplateTail, LineTerminator, PrivateIdentifier, ReservedWord, RightBracePunctuator, Rule, WhiteSpace};
+use lexical_grammar::{Comment, CommonToken, DivPunctuator, Ecma262Parser, HashbangComment, InputElementDiv, InputElementHashbangOrRegExp, InputElementRegExp, InputElementRegExpOrTemplateTail,, LineTerminator, PrivateIdentifier, ReservedWord, RightBracePunctuator, Rule, WhiteSpace};
 use pest::{iterators::Pairs, Parser};
 
 /// Kind of a grammar used for tokenization.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,12 +10,12 @@
 pub mod lexical_grammar;
 
 use from_pest::FromPest;
-use lexical_grammar::{Comment, CommonToken, DivPunctuator, Ecma262Parser, HashbangComment, IdentifierName, InputElementDiv, InputElementHashbangOrRegExp, InputElementRegExp, InputElementRegExpOrTemplateTail, InputElementTemplateTail, LineTerminator, PrivateIdentifier, ReservedWord, RightBracePunctuator, Rule, WhiteSpace};
+use lexical_grammar::{Comment, CommonToken, DivPunctuator, Ecma262Parser, HashbangComment, IdentifierName, InputElementDiv, InputElementHashbangOrRegExp, InputElementRegExp, InputElementRegExpOrTemplateTail, InputElementTemplateTail, PrivateIdentifier, ReservedWord, Rule};
 use pest::{iterators::Pairs, Parser};
 
 /// An output of the tokenization step
 #[derive(Debug, Eq, PartialEq)]
-pub enum Token<'src> {
+pub enum UnpackedToken<'src> {
     WhiteSpace,
     LineTerminator,
     Comment(Comment),
@@ -72,17 +72,6 @@ enum PackedToken<'src> {
     TemplateTail(InputElementTemplateTail),
 }
 
-enum UnpackedToken<'src> {
-    Comment(Comment),
-    CommonToken(CommonToken),
-    DivPunctuator(DivPunctuator),
-    HashbangComment(HashbangComment<'src>),
-    LineTerminator(LineTerminator),
-    ReservedWord(ReservedWord),
-    RightBracePunctuator(RightBracePunctuator),
-    WhiteSpace(WhiteSpace),
-}
-
 /// Extract a first token from a `.js`/`.mjs` text.
 ///
 /// Returns a tuple of the token and an unprocessed input tail.
@@ -99,7 +88,7 @@ enum UnpackedToken<'src> {
 ///
 /// Will panic if the root grammar errorneously defines an empty goal symbol.
 /// This means a broken grammar file used by developers to build the parser.
-pub fn get_next_token(input: &str, mode: GoalSymbols) -> Result<(Token, &str), String> {
+pub fn get_next_token(input: &str, mode: GoalSymbols) -> Result<(UnpackedToken, &str), String> {
     let goal = match mode {
         GoalSymbols::InputElementHashbangOrRegExp => Rule::InputElementHashbangOrRegExp,
         GoalSymbols::InputElementRegExpOrTemplateTail => Rule::InputElementRegExpOrTemplateTail,
@@ -133,7 +122,7 @@ pub fn get_next_token(input: &str, mode: GoalSymbols) -> Result<(Token, &str), S
                     PackedToken::Div(typed.unwrap())
                 },
             };
-            Ok((flatten_token(unpack_token(typed_packed)), tail))
+            Ok((unpack_token(typed_packed), tail))
         },
         Err(error) => Err(error.to_string())
     }
@@ -192,19 +181,6 @@ fn unpack_token(input: PackedToken<'_>) -> UnpackedToken<'_> {
                 InputElementTemplateTail::ReservedWord(item) => UnpackedToken::ReservedWord(item),
             }
         },
-    }
-}
-
-fn flatten_token(symbol_tree: UnpackedToken) -> Token {
-    match symbol_tree {
-        UnpackedToken::WhiteSpace(_) => Token::WhiteSpace,
-        UnpackedToken::Comment(kind) => Token::Comment(kind),
-        UnpackedToken::HashbangComment(line) => Token::HashbangComment(line),
-        UnpackedToken::CommonToken(token) => Token::CommonToken(token),
-        UnpackedToken::DivPunctuator(punctuator) => Token::DivPunctuator(punctuator),
-        UnpackedToken::ReservedWord(keyword) => Token::ReservedWord(keyword),
-        UnpackedToken::RightBracePunctuator(_) => Token::ClosingBrace,
-        UnpackedToken::LineTerminator(_) => Token::LineTerminator,
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@
 pub mod lexical_grammar;
 
 use from_pest::FromPest;
-use lexical_grammar::{Comment, CommonToken, DivPunctuator, Ecma262Parser, HashbangComment, IdentifierName, InputElementDiv, InputElementHashbangOrRegExp, InputElementRegExp, InputElementRegExpOrTemplateTail, InputElementTemplateTail, PrivateIdentifier, ReservedWord, Rule};
+use lexical_grammar::{Comment, CommonToken, DivPunctuator, Ecma262Parser, HashbangComment, IdentifierName, InputElementDiv, InputElementHashbangOrRegExp, InputElementRegExp, InputElementRegExpOrTemplateTail, InputElementTemplateTail, LineTerminator, PrivateIdentifier, ReservedWord, RightBracePunctuator, Rule, WhiteSpace};
 use pest::{iterators::Pairs, Parser};
 
 /// Kind of a grammar used for tokenization.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@
 pub mod lexical_grammar;
 
 use from_pest::FromPest;
-use lexical_grammar::{Comment, CommonToken, DivPunctuator, Ecma262Parser, HashbangComment, InputElementDiv, InputElementHashbangOrRegExp, InputElementRegExp, InputElementRegExpOrTemplateTail,, LineTerminator, PrivateIdentifier, ReservedWord, RightBracePunctuator, Rule, WhiteSpace};
+use lexical_grammar::{Comment, CommonToken, DivPunctuator, Ecma262Parser, HashbangComment, InputElementDiv, InputElementHashbangOrRegExp, InputElementRegExp, InputElementRegExpOrTemplateTail, InputElementTemplateTail, LineTerminator, ReservedWord, RightBracePunctuator, Rule, WhiteSpace};
 use pest::{iterators::Pairs, Parser};
 
 /// Kind of a grammar used for tokenization.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,18 +16,14 @@ use pest::{iterators::Pairs, Parser};
 /// An output of the tokenization step
 #[derive(Debug, Eq, PartialEq)]
 pub enum UnpackedToken<'src> {
-    WhiteSpace,
-    LineTerminator,
     Comment(Comment),
-    HashbangComment(HashbangComment<'src>),
-
     CommonToken(CommonToken),
-    ClosingBrace,
     DivPunctuator(DivPunctuator),
-
-    IdentifierName(IdentifierName),
-    PrivateIdentifier(PrivateIdentifier),
+    HashbangComment(HashbangComment<'src>),
+    LineTerminator(LineTerminator),
     ReservedWord(ReservedWord),
+    RightBracePunctuator(RightBracePunctuator),
+    WhiteSpace(WhiteSpace),
 }
 
 /// Kind of a grammar used for tokenization.

--- a/tests/test_tokenizer.rs
+++ b/tests/test_tokenizer.rs
@@ -36,6 +36,7 @@ mod tests {
             LeftShiftAssignment,
             Less,
             LessOrEqual,
+            LineTerminator,
             LooseEquality,
             LooseInequality,
             Modulo,
@@ -65,6 +66,7 @@ mod tests {
             Subtraction,
             UnsignedRightShift,
             UnsignedRightShiftAssignment,
+            WhiteSpace,
         },
         Token,
     };
@@ -103,7 +105,7 @@ mod tests {
         )]
         mode: GoalSymbols,
     ) {
-        assert_ok_eq!(get_next_token(tested, mode), (Token::WhiteSpace, ""));
+        assert_ok_eq!(get_next_token(tested, mode), (Token::WhiteSpace(WhiteSpace), ""));
     }
 
     #[rstest]
@@ -119,7 +121,7 @@ mod tests {
         )]
         mode: GoalSymbols,
     ) {
-        assert_ok_eq!(get_next_token(tested, mode), (Token::LineTerminator, ""));
+        assert_ok_eq!(get_next_token(tested, mode), (Token::LineTerminator(LineTerminator), ""));
     }
 
     #[rstest]
@@ -136,7 +138,7 @@ mod tests {
         // The parser consumes `\r\n` as string literal line continuation only.
         // See how `LineTerminator` and `LineTerminatorSequence` grammar rules
         // are defined and used in ECMA-262.
-        assert_ok_eq!(get_next_token("\r\n", mode), (Token::LineTerminator, "\n"));
+        assert_ok_eq!(get_next_token("\r\n", mode), (Token::LineTerminator(LineTerminator), "\n"));
     }
 
     #[rstest]

--- a/tests/test_tokenizer.rs
+++ b/tests/test_tokenizer.rs
@@ -56,6 +56,7 @@ mod tests {
             OrAssignment,
             OtherPunctuator,
             Punctuator,
+            RightBracePunctuator,
             RightShift,
             RightShiftAssignment,
             StrictEquality,
@@ -253,13 +254,13 @@ mod tests {
 
         assert_ok_eq!(
             get_next_token("}", GoalSymbols::InputElementDiv),
-            (Token::ClosingBrace, "")
+            (Token::RightBracePunctuator(RightBracePunctuator), "")
         );
         assert_err!(get_next_token("}", GoalSymbols::InputElementHashbangOrRegExp));
         assert_err!(get_next_token("}", GoalSymbols::InputElementRegExpOrTemplateTail));
         assert_ok_eq!(
             get_next_token("}", GoalSymbols::InputElementRegExp),
-            (Token::ClosingBrace, "")
+            (Token::RightBracePunctuator(RightBracePunctuator), "")
         );
         assert_err!(get_next_token("}", GoalSymbols::InputElementTemplateTail));
 


### PR DESCRIPTION
After all previous merge requests in the parent issue, both enums are the same. So, we can finally remove token repacking in flatten_token function.

Note: to minimize the diff, use UnpackedToken for a while, until we replace all mentions of UnpackedToken in the follow-up PR.

- Issue: gh-115