### PR TITLE
gh-130: Add a project scope into README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,9 @@ It conforms to:
 - The JSON data interchange syntax (ECMA-404, 2nd edition) ECMA-404 <sup>todo</sup>
 - Unicode 15.1 <sup>in progress</sup>
 
+Implemented as an abstract syntax tree interpreter mulling through
+in-specification abstract operations.
+
 [ECMAScript 2024]: https://262.ecma-international.org/15.0/index.html
 
 ## Copyright and License Information


### PR DESCRIPTION
This is required for proper separation without over-engineering.

- Issue: gh-130